### PR TITLE
Remove newlines between elements

### DIFF
--- a/lib/rux/parser.rb
+++ b/lib/rux/parser.rb
@@ -189,8 +189,8 @@ module Rux
 
     def squeeze_lit(lit)
       lit
-        .sub(/\A\s+/) { |s| s.match?(/[\r\n]/) ? s.lstrip : s }
-        .sub(/\s+\z/) { |s| s.match?(/[\r\n]/) ? s.rstrip : s }
+        .sub(/\A\s+/) { |s| s.match?(/[\r\n]/) ? "" : s }
+        .sub(/\s+\z/) { |s| s.match?(/[\r\n]/) ? "" : s }
         .gsub(/\s+/, " ")
     end
 

--- a/lib/rux/parser.rb
+++ b/lib/rux/parser.rb
@@ -188,7 +188,10 @@ module Rux
     end
 
     def squeeze_lit(lit)
-      lit.gsub(/\s/, ' ').squeeze(' ')
+      lit
+        .sub(/\A\s+/) { |s| s.match?(/[\r\n]/) ? s.lstrip : s }
+        .sub(/\s+\z/) { |s| s.match?(/[\r\n]/) ? s.rstrip : s }
+        .gsub(/\s+/, " ")
     end
 
     def literal_ruby_code

--- a/spec/parser_spec.rb
+++ b/spec/parser_spec.rb
@@ -136,18 +136,14 @@ describe Rux::Parser do
 
     expect(compile(rux_code)).to eq(<<~RUBY.strip)
       render(Outer.new) {
-        Rux.create_buffer.tap { |_rux_buf_|
-          _rux_buf_ << " "
-          _rux_buf_ << 5.times.map {
-            render(Inner.new) {
-              Rux.create_buffer.tap { |_rux_buf_|
-                _rux_buf_ << "What a "
-                _rux_buf_ << @thing
-              }.to_s
-            }
+        5.times.map {
+          render(Inner.new) {
+            Rux.create_buffer.tap { |_rux_buf_|
+              _rux_buf_ << "What a "
+              _rux_buf_ << @thing
+            }.to_s
           }
-          _rux_buf_ << " "
-        }.to_s
+        }
       }
     RUBY
   end
@@ -163,18 +159,14 @@ describe Rux::Parser do
 
     expect(compile(rux_code)).to eq(<<~RUBY.strip)
       Rux.tag("div") {
-        Rux.create_buffer.tap { |_rux_buf_|
-          _rux_buf_ << " "
-          _rux_buf_ << 5.times.map {
-            Rux.tag("p") {
-              Rux.create_buffer.tap { |_rux_buf_|
-                _rux_buf_ << "What a "
-                _rux_buf_ << @thing
-              }.to_s
-            }
+        5.times.map {
+          Rux.tag("p") {
+            Rux.create_buffer.tap { |_rux_buf_|
+              _rux_buf_ << "What a "
+              _rux_buf_ << @thing
+            }.to_s
           }
-          _rux_buf_ << " "
-        }.to_s
+        }
       }
     RUBY
   end
@@ -198,18 +190,14 @@ describe Rux::Parser do
 
     expect(compile(rux_code)).to eq(<<~RUBY.strip)
       render(Outer.new) {
-        Rux.create_buffer.tap { |_rux_buf_|
-          _rux_buf_ << " "
-          _rux_buf_ << 5.times.map {
-            Rux.tag("div") {
-              Rux.create_buffer.tap { |_rux_buf_|
-                _rux_buf_ << "So "
-                _rux_buf_ << @cool
-              }.to_s
-            }
+        5.times.map {
+          Rux.tag("div") {
+            Rux.create_buffer.tap { |_rux_buf_|
+              _rux_buf_ << "So "
+              _rux_buf_ << @cool
+            }.to_s
           }
-          _rux_buf_ << " "
-        }.to_s
+        }
       }
     RUBY
   end
@@ -249,6 +237,35 @@ describe Rux::Parser do
           _rux_buf_ << first
           _rux_buf_ << " "
           _rux_buf_ << second
+        }.to_s
+      }
+    RUBY
+  end
+
+  it 'does not emit spaces for newlines or indentation' do
+    code = <<~RUX
+      <Hello>
+        <Hola>{first} {second}</Hola>
+        <Hola>{first} {second}</Hola>
+      </Hello>
+    RUX
+    expect(compile(code)).to eq(<<~RUBY.strip)
+      render(Hello.new) {
+        Rux.create_buffer.tap { |_rux_buf_|
+          _rux_buf_ << render(Hola.new) {
+            Rux.create_buffer.tap { |_rux_buf_|
+              _rux_buf_ << first
+              _rux_buf_ << " "
+              _rux_buf_ << second
+            }.to_s
+          }
+          _rux_buf_ << render(Hola.new) {
+            Rux.create_buffer.tap { |_rux_buf_|
+              _rux_buf_ << first
+              _rux_buf_ << " "
+              _rux_buf_ << second
+            }.to_s
+          }
         }.to_s
       }
     RUBY

--- a/spec/render_spec.rb
+++ b/spec/render_spec.rb
@@ -15,7 +15,7 @@ describe Rux do
       </div>
     RUBY
 
-    expect(result).to eq("<div> <p>Welcome!</p><p>Welcome!</p><p>Welcome!</p> </div>")
+    expect(result).to eq("<div><p>Welcome!</p><p>Welcome!</p><p>Welcome!</p></div>")
   end
 
   it 'handles rux tags inside ruby code' do
@@ -27,7 +27,7 @@ describe Rux do
       </div>
     RUBY
 
-    expect(result).to eq("<div> <p>Welcome!</p><p>Welcome!</p><p>Welcome!</p> </div>")
+    expect(result).to eq("<div><p>Welcome!</p><p>Welcome!</p><p>Welcome!</p></div>")
   end
 
   it 'correctly handles keyword arguments (ruby 3)' do
@@ -36,5 +36,31 @@ describe Rux do
     RUBY
 
     expect(result).to eq("<p>a and b</p>")
+  end
+
+  it 'removes whitespace between elements and text' do
+    result = render(<<~RUBY)
+      <div>
+        <p>Hello World</p>
+
+        <p>
+          Hello World
+        </p>
+
+        <p>
+          Hello
+          World
+        </p>
+
+        <p>
+
+          Hello World
+        </p>
+      </div>
+    RUBY
+
+    expect(result).to eq(
+      "<div><p>Hello World</p><p>Hello World</p><p>Hello World</p><p>Hello World</p></div>"
+    )
   end
 end


### PR DESCRIPTION
Rux is pretty cool and I would like to use it, however I'm getting some unnecessary whitespace that end up in the DOM and cause layout issues.

[JSX removes whitespace between elements](https://reactjs.org/docs/jsx-in-depth.html#string-literals-1), while Rux doesn't.

Input:

```jsx
<ul>
  <li>foo</li>
  <li>bar</li>
</ul>
```

JSX output:

```jsx
<ul><li>foo</li><li>bar</li></ul>
```

Rux output:

```jsx
<ul> <li>foo</li> <li>bar</li> </ul>
```

This change should make Rux more consistent with JSX.

I don't understand how the parser works, so I just made the simplest thing possible to fix this.
Can it be done in a better way?