### PR TITLE
Fix serialize html attributes

### DIFF
--- a/lib/rux/default_tag_builder.rb
+++ b/lib/rux/default_tag_builder.rb
@@ -13,7 +13,7 @@ module Rux
       ''.tap do |result|
         attributes.each_pair.with_index do |(k, v), idx|
           result << ' ' unless idx == 0
-          result << "#{k.to_s.gsub('-', '_')}=\"#{CGI.escape_html(v.to_s)}\""
+          result << "#{k.to_s}=\"#{CGI.escape_html(v.to_s)}\""
         end
       end
     end

--- a/lib/rux/version.rb
+++ b/lib/rux/version.rb
@@ -1,3 +1,3 @@
 module Rux
-  VERSION = '1.1.1'
+  VERSION = '1.1.2'
 end


### PR DESCRIPTION
When we finally serialize html attributes - we shouldn't replace `-` (dash) to `_` (underscore). So, this fix keeps original dashed attributes😅