### PR TITLE
Don't slugify HTML attributes in the tag builder either

### DIFF
--- a/README.md
+++ b/README.md
@@ -170,13 +170,15 @@ end
 
 In other words, positional arguments are not allowed. This is because there's no such thing as a positional HTML attribute - all HTML attributes are key/value pairs. So, in order to match up with HTML, rux components are written with keyword arguments.
 
-Note also that the rux parser will replace dashes with underscores in rux tag attributes to adhere to both HTML and Ruby syntax conventions, since HTML attributes use dashes while Ruby keyword arguments use underscores. For example, here's how to write a rux tag for `MyComponent` above:
+Note also that the rux parser will replace dashes with underscores in component tag attributes to adhere to both HTML and Ruby syntax conventions, since HTML attributes use dashes while Ruby keyword arguments use underscores. For example, here's how to write a rux tag for `MyComponent` above:
 
 ```ruby
 <MyComponent first-name="Homer" last-name="Simpson" />
 ```
 
 Notice that the rux attribute "first-name" is passed to `MyComponent#initialize` as "first_name".
+
+Attributes on regular tags, i.e. non-component tags like `<div>` and `<span>`, are not modified. In other words, `<div data-foo="foo">` does _not_ become `<div data_foo="foo">` because that would be very annoying.
 
 ## How it Works
 

--- a/lib/rux/default_tag_builder.rb
+++ b/lib/rux/default_tag_builder.rb
@@ -13,7 +13,7 @@ module Rux
       ''.tap do |result|
         attributes.each_pair.with_index do |(k, v), idx|
           result << ' ' unless idx == 0
-          result << "#{k.to_s.gsub('-', '_')}=\"#{CGI.escape_html(v.to_s)}\""
+          result << "#{k}=\"#{CGI.escape_html(v.to_s)}\""
         end
       end
     end

--- a/spec/render_spec.rb
+++ b/spec/render_spec.rb
@@ -63,4 +63,24 @@ describe Rux do
       "<div><p>Hello World</p><p>Hello World</p><p>Hello World</p><p>Hello World</p></div>"
     )
   end
+
+  it 'slugifies ruby arguments' do
+    result = render(<<~RUBY)
+      <DataComponent data-foo="foo" />
+    RUBY
+
+    expect(result).to eq(
+      "<div data-foo=\"foo\"></div>"
+    )
+  end
+
+  it 'does not slugify HTML attributes' do
+    result = render(<<~RUBY)
+      <div data-foo="bar"></div>
+    RUBY
+
+    expect(result).to eq(
+      "<div data-foo=\"bar\"></div>"
+    )
+  end
 end

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -33,5 +33,15 @@ class ArgsComponent < ViewComponent::Base
   end
 end
 
+class DataComponent < ViewComponent::Base
+  def initialize(data_foo:)
+    @data_foo = data_foo
+  end
+
+  def call
+    "<div data-foo=\"#{@data_foo}\"></div>"
+  end
+end
+
 RSpec.configure do |config|
 end


### PR DESCRIPTION
This PR replaces #6 and is a follow-on to https://github.com/camertron/rux/commit/e77c509ba3c34762eb11d90bea1ad353e572ed62. HTML attributes should not be slugified when emitted either.